### PR TITLE
Add to_bson methods where missing. New tests and improve current tests.

### DIFF
--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -1,0 +1,66 @@
+# Copyright (C) 2009-2014 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modified 2015 Elastic
+
+module BSON
+
+  # Injects behaviour for encoding and decoding BigDecimal values
+  # to and from # raw bytes as specified by the BSON spec.
+  #
+  # @see http://bsonspec.org/#/specification
+  module BigDecimal
+
+    # A floating point is type 0x01 in the BSON spec.
+    BSON_TYPE = 1.chr.force_encoding(BINARY).freeze
+
+    # The pack directive is for 8 byte floating points.
+    PACK = "E".freeze
+
+    # Get the floating point as encoded BSON.
+    # @example Get the floating point as encoded BSON.
+    #   1.221311.to_bson
+    # @return [ String ] The encoded string.
+    # @see http://bsonspec.org/#/specification
+    def to_bson(encoded = ''.force_encoding(BINARY))
+      encoded << [ self.to_f ].pack(PACK)
+    end
+
+    module ClassMethods
+
+      # Deserialize an instance of a BigDecimal from a BSON double.
+      # @param [ ByteBuffer ] buffer The byte buffer.
+      # @return [ BigDecimal ] The decoded BigDecimal.
+      # @see http://bsonspec.org/#/specification
+      def from_bson(bson)
+        from_bson_double(bson.read(8))
+      end
+
+      private
+
+      def from_bson_double(double)
+        new(double.unpack(PACK).first.to_s)
+      end
+    end
+
+    # Register this type when the module is loaded.
+    Registry.register(BSON_TYPE, ::BigDecimal)
+  end
+
+  # Enrich the core BigDecimal class with this module.
+  #
+  # @since 2.0.0
+  ::BigDecimal.send(:include, BigDecimal)
+  ::BigDecimal.send(:extend, BigDecimal::ClassMethods)
+end

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -34,13 +34,13 @@ module BSON
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
     def to_bson(encoded = ''.force_encoding(BINARY))
-      encoded << [ self.to_f ].pack(PACK)
+      encoded << [ self ].pack(PACK)
     end
 
     module ClassMethods
 
       # Deserialize an instance of a BigDecimal from a BSON double.
-      # @param [ ByteBuffer ] buffer The byte buffer.
+      # @param [ BSON ] bson object from Mongo.
       # @return [ BigDecimal ] The decoded BigDecimal.
       # @see http://bsonspec.org/#/specification
       def from_bson(bson)

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -1,0 +1,76 @@
+# Copyright (C) 2009-2014 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modified 2015 Elastic
+
+module BSON
+
+  # Injects behaviour for encoding and decoding time values to
+  # and from raw bytes as specified by the BSON spec.
+  #
+  # @see http://bsonspec.org/#/specification
+  module LogStashEvent
+
+    # An Event is an embedded document is type 0x03 in the BSON spec..
+    BSON_TYPE = 3.chr.force_encoding(BINARY).freeze
+
+    # Get the event as encoded BSON.
+    # @example Get the hash as encoded BSON.
+    #   Event.new("field" => "value").to_bson
+    # @return [ String ] The encoded string.
+    # @see http://bsonspec.org/#/specification
+     def to_bson(buffer = ByteBuffer.new)
+      position = buffer.length
+      buffer.put_int32(0)
+      to_hash_with_metadata.each do |field, value|
+        buffer.put_byte(value.bson_type)
+        buffer.put_cstring(field.to_bson_key)
+        value.to_bson(buffer)
+      end
+      buffer.put_byte(NULL_BYTE)
+      buffer.replace_int32(position, buffer.length - position)
+    end
+
+    # Converts the event to a normalized value in a BSON document.
+    # @example Convert the event to a normalized value.
+    #   event.to_bson_normalized_value
+    # @return [ BSON::Document ] The normalized event.
+    def to_bson_normalized_value
+      Document.new(self)
+    end
+
+    module ClassMethods
+      # Deserialize the Event from BSON.
+      # @param [ ByteBuffer ] buffer The byte buffer.
+      # @return [ Event ] The decoded bson document.
+      # @see http://bsonspec.org/#/specification
+      def from_bson(buffer)
+        hash = Hash.new
+        buffer.get_int32 # Throw away the size.
+        while (type = buffer.get_byte) != NULL_BYTE
+          field = buffer.get_cstring
+          hash.store(field, BSON::Registry.get(type).from_bson(buffer))
+        end
+        new(hash)
+      end
+    end
+
+    # Register this type when the module is loaded.
+    Registry.register(BSON_TYPE, ::LogStash::Event)
+  end
+
+  # Enrich the core LogStash::Event class with this module.
+  ::LogStash::Event.send(:include, ::LogStashEvent)
+  ::LogStash::Event.send(:extend, ::LogStashEvent::ClassMethods)
+end

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -33,7 +33,7 @@ module BSON
      def to_bson(buffer = ByteBuffer.new)
       position = buffer.length
       buffer.put_int32(0)
-      to_hash_with_metadata.each do |field, value|
+      to_hash.each do |field, value|
         buffer.put_byte(value.bson_type)
         buffer.put_cstring(field.to_bson_key)
         value.to_bson(buffer)

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -36,7 +36,7 @@ module BSON
       # @see http://bsonspec.org/#/specification
       def from_bson(bson)
         seconds, fragment = BSON::Int64.from_bson(bson).divmod(1000)
-        new(at(seconds, fragment * 1000))
+        new(::Time.at(seconds, fragment * 1000).utc)
       end
     end
 

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -1,0 +1,50 @@
+# Copyright (C) 2009-2014 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modified 2015 Elastic
+
+module BSON
+
+  # Injects behaviour for encoding and decoding time values to
+  # and from raw bytes as specified by the BSON spec.
+  #
+  # @see http://bsonspec.org/#/specification
+  module LogStashTimestamp
+
+    # A time is type 0x09 in the BSON spec.
+    BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
+
+    def to_bson(encoded = ''.force_encoding(BINARY))
+      time.to_bson(encoded)
+    end
+
+    module ClassMethods
+      # Deserialize UTC time from BSON.
+      # @param [ BSON ] bson encoded time.
+      # @return [ ::LogStash::Timestamp ] The decoded UTC time as a ::LogStash::Timestamp.
+      # @see http://bsonspec.org/#/specification
+      def from_bson(bson)
+        seconds, fragment = BSON::Int64.from_bson(bson).divmod(1000)
+        new(at(seconds, fragment * 1000))
+      end
+    end
+
+    # Register this type when the module is loaded.
+    Registry.register(BSON_TYPE, ::LogStash::Timestamp)
+  end
+
+  # Enrich the core LogStash::Timestamp class with this module.
+  ::LogStash::Timestamp.send(:include, LogStashTimestamp)
+  ::LogStash::Timestamp.send(:extend, LogStashTimestamp::ClassMethods)
+end

--- a/lib/logstash/outputs/mongodb.rb
+++ b/lib/logstash/outputs/mongodb.rb
@@ -44,7 +44,6 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
   def receive(event)
     begin
       # Our timestamp object now has a to_bson method, using it here
-      # why not use to_hash_with_metadata?
       # {}.merge(other) so we don't taint the event hash innards
       document = {}.merge(event.to_hash)
       if !@isodate

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -5,7 +5,7 @@ require 'stringio'
 
 describe ::BigDecimal do
   let(:a_number) { "4321.1234" }
-  let(:bson_number) { "Tt$\x97\x1F\xE1\xB0@".force_encoding(BSON::BINARY) }
+  let(:bson_number) { 4321.1234.to_bson }
 
   subject { described_class.new(a_number) }
 
@@ -14,18 +14,17 @@ describe ::BigDecimal do
   end
 
   it "to_bson returns a binary encoded number" do
-    expect(subject.to_bson).to eq(bson_number)
+    expect(subject.to_bson).to eq(4321.1234.to_bson)
   end
 
   it "bson_type returns a binary encoded 1" do
-    expect(subject.bson_type).to eq("\x01".force_encoding(BSON::BINARY))
+    expect(subject.bson_type).to eq(12.34.bson_type)
   end
 
   describe "class methods" do
     it "builds a new BigDecimal from BSON" do
-      decoded = described_class.from_bson(StringIO.new(bson_number))
-      expect(decoded).to eq(subject)
-      expect(decoded).to be_a(BigDecimal)
+      decoded = described_class.from_bson(StringIO.new(4321.1234.to_bson))
+      expect(decoded).to eql(BigDecimal.new(a_number))
     end
   end
 end

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require 'bigdecimal'
+require_relative "../spec_helper"
+require 'stringio'
+
+describe ::BigDecimal do
+  let(:a_number) { "4321.1234" }
+  let(:bson_number) { "Tt$\x97\x1F\xE1\xB0@".force_encoding(BSON::BINARY) }
+
+  subject { described_class.new(a_number) }
+
+  it "responds to to_bson" do
+    expect(subject).to respond_to(:to_bson)
+  end
+
+  it "to_bson returns a binary encoded number" do
+    expect(subject.to_bson).to eq(bson_number)
+  end
+
+  it "bson_type returns a binary encoded 1" do
+    expect(subject.bson_type).to eq("\x01".force_encoding(BSON::BINARY))
+  end
+
+  describe "class methods" do
+    it "builds a new BigDecimal from BSON" do
+      decoded = described_class.from_bson(StringIO.new(bson_number))
+      expect(decoded).to eq(subject)
+      expect(decoded).to be_a(BigDecimal)
+    end
+  end
+end

--- a/spec/bson/logstash_timestamp_spec.rb
+++ b/spec/bson/logstash_timestamp_spec.rb
@@ -3,28 +3,29 @@ require_relative "../spec_helper"
 require 'stringio'
 
 describe ::LogStash::Timestamp do
-  let(:a_time) { Time.utc(1918,11,11,11,0,0) }
-  let(:bson_time) { "\x80{y@\x88\xFE\xFF\xFF".force_encoding(BSON::BINARY) }
+  let(:time_array) { [1918,11,11,11,0,0, "+00:00"] }
+  let(:a_time) { Time.utc(*time_array) }
+  let(:bson_time) { Time.utc(*time_array).to_bson }
 
-  subject { described_class.new(a_time) }
+  subject(:timestamp) { described_class.new(a_time) }
 
   it "responds to to_bson" do
     expect(subject).to respond_to(:to_bson)
   end
 
   it "to_bson returns a binary encoded timestamp" do
-    expect(subject.to_bson).to eq(bson_time)
+    expect(timestamp.to_bson).to eq(bson_time)
   end
 
   it "bson_type returns a binary encoded 9" do
-    expect(subject.bson_type).to eq("\x09".force_encoding(BSON::BINARY))
+    expect(subject.bson_type).to eq(a_time.bson_type)
   end
 
   describe "class methods" do
     it "builds a new Timestamp from BSON" do
-      decoded = described_class.from_bson(StringIO.new(bson_time))
-      expect(decoded).to eq(subject)
-      expect(decoded).to be_a(::LogStash::Timestamp)
+      expected = ::LogStash::Timestamp.new(a_time)
+      decoded = ::LogStash::Timestamp.from_bson(StringIO.new(bson_time))
+      expect(decoded <=> expected).to eq(0)
     end
   end
 end

--- a/spec/bson/logstash_timestamp_spec.rb
+++ b/spec/bson/logstash_timestamp_spec.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+require_relative "../spec_helper"
+require 'stringio'
+
+describe ::LogStash::Timestamp do
+  let(:a_time) { Time.new(1918,11,11,11,0,0) }
+  let(:bson_time) { "\x80{y@\x88\xFE\xFF\xFF".force_encoding(BSON::BINARY) }
+
+  subject { described_class.new(a_time) }
+
+  it "responds to to_bson" do
+    expect(subject).to respond_to(:to_bson)
+  end
+
+  it "to_bson returns a binary encoded timestamp" do
+    expect(subject.to_bson).to eq(bson_time)
+  end
+
+  it "bson_type returns a binary encoded 9" do
+    expect(subject.bson_type).to eq("\x09".force_encoding(BSON::BINARY))
+  end
+
+  describe "class methods" do
+    it "builds a new Timestamp from BSON" do
+      decoded = described_class.from_bson(StringIO.new(bson_time))
+      expect(decoded).to eq(subject)
+      expect(decoded).to be_a(::LogStash::Timestamp)
+    end
+  end
+end

--- a/spec/bson/logstash_timestamp_spec.rb
+++ b/spec/bson/logstash_timestamp_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper"
 require 'stringio'
 
 describe ::LogStash::Timestamp do
-  let(:a_time) { Time.new(1918,11,11,11,0,0) }
+  let(:a_time) { Time.utc(1918,11,11,11,0,0) }
   let(:bson_time) { "\x80{y@\x88\xFE\xFF\xFF".force_encoding(BSON::BINARY) }
 
   subject { described_class.new(a_time) }

--- a/spec/integration/mongodb_spec.rb
+++ b/spec/integration/mongodb_spec.rb
@@ -6,16 +6,21 @@ describe LogStash::Outputs::Mongodb, :integration => true do
   let(:uri)        { 'mongodb://localhost:27017' }
   let(:database)   { 'logstash' }
   let(:collection) { 'logs' }
+  let(:uuid)       { SecureRandom.uuid }
 
   let(:config) do
-    { "uri" => uri, "database" => database, "collection" => collection }
+    { "uri" => uri, "database" => database,
+      "collection" => collection, "isodate" => true }
   end
 
   describe "#send" do
 
     subject { LogStash::Outputs::Mongodb.new(config) }
 
-    let(:properties) { { "message" => "This is a message!"} }
+    let(:properties) { { "message" => "This is a message!",
+                         "uuid" => uuid, "number" => BigDecimal.new("4321.1234"),
+                         "utf8" => "żółć", "int" => 42,
+                         "arry" => [42, "string", 4321.1234]} }
     let(:event)      { LogStash::Event.new(properties) }
 
     before(:each) do

--- a/spec/outputs/mongodb_spec.rb
+++ b/spec/outputs/mongodb_spec.rb
@@ -21,7 +21,10 @@ describe LogStash::Outputs::Mongodb do
 
     subject { LogStash::Outputs::Mongodb.new(config) }
 
-    let(:properties) { { "message" => "This is a message!"} }
+    let(:properties) { { "message" => "This is a message!",
+                         "uuid" => SecureRandom.uuid,
+                         "number" => BigDecimal.new("4321.1234"),
+                         "utf8" => "żółć"} }
     let(:event)      { LogStash::Event.new(properties) }
     let(:connection) { double("connection") }
     let(:client)     { double("client") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,6 @@ RSpec::Matchers.define :have_received do |event|
   match do |subject|
     client     = subject.instance_variable_get("@db")
     collection = subject.instance_variable_get("@collection")
-    client["#{collection}"].find("@timestamp" => event["@timestamp"].to_json).count > 0
+    client["#{collection}"].find("uuid" => event["uuid"]).count > 0
   end
 end


### PR DESCRIPTION
NOTES TO REVIEWERS:
- This gives our Event, Timestamp class and BigDecimal proper bson support like the BSON ruby library does.
- There are tests for the bson support.
- We are not currently using the Event bson support at the moment because we mutate the hash before giving it to Mongo
- Improved the `receive(event)` method a bit.
- Minor improvement to the mongo unit test
- major improvement to the the integration test. Used a uuid to search for the document in Mongo because the timestamp may be an ISODate object and not a String. Added a few other objects incl. BigDecimal to the Event content to better test integration.  Although the test does not check the contents of what it reads back from Mongo, I did it manually in the mongo console.
- I have a question: why do we omit the metadata from the document sent to Mongo?

From Mongo console

```
MongoDB shell version: 3.0.7
connecting to: test
Server has startup warnings:
2015-12-08T12:34:11.589+0000 I CONTROL  [initandlisten]
2015-12-08T12:34:11.589+0000 I CONTROL  [initandlisten] ** WARNING: soft rlimits too low. Number
  of files is 256, should be at least 1000
> use logstash
> db.logs.find()
{ "_id" : ObjectId("56671628146fbfeff9000001"), "message" : "This is a message!",
"uuid" : "3777a8f0-99a5-4df6-8772-d3e9392fd374", "number" : 4321.1234,
"utf8" : "żółć", "int" : 42, "arry" : [ 42, "string", 4321.1234 ],
"@version" : "1", "@timestamp" : ISODate("2015-12-08T17:40:56.932Z") }
```
