### PR TITLE
Update plugin api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# 2.0.5
+## 3.0.0
+ - Breaking: Updated plugin to use new Java Event APIs
+ - relax logstash-core-plugin-api constrains
+ - update .travis.yml
+
+## 2.0.5
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.4
+
+## 2.0.4
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.3
  - Patch Timestamp and BigDecimal with to_bson method and register with BSON.
 

--- a/lib/logstash/outputs/mongodb.rb
+++ b/lib/logstash/outputs/mongodb.rb
@@ -48,10 +48,10 @@ class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
       document = {}.merge(event.to_hash)
       if !@isodate
         # not using timestamp.to_bson
-        document["@timestamp"] = event["@timestamp"].to_json
+        document["@timestamp"] = event.timestamp.to_json
       end
       if @generateId
-        document["_id"] = BSON::ObjectId.new(nil, event["@timestamp"])
+        document["_id"] = BSON::ObjectId.new(nil, event.timestamp)
       end
       @db[event.sprintf(@collection)].insert_one(document)
     rescue => e

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-mongodb'
-  s.version         = '2.0.5'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Store events into MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'mongo', '~> 2.0.6'
 


### PR DESCRIPTION
- Breaking: Updated plugin to use new Java Event APIs
- relax logstash-core-plugin-api constrains
- update .travis.yml