### PR TITLE
Remove comments causing docgen issues and make a few edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+ - Docs: Fix doc generation issue by removing extraneous comments and adding a short description of the plugin
+
 ## 3.0.0
  - Breaking: Updated plugin to use new Java Event APIs
  - relax logstash-core-plugin-api constrains

--- a/lib/logstash/outputs/mongodb.rb
+++ b/lib/logstash/outputs/mongodb.rb
@@ -4,29 +4,29 @@ require "logstash/namespace"
 require "mongo"
 require_relative "bson/big_decimal"
 require_relative "bson/logstash_timestamp"
-# require_relative "bson/logstash_event"
 
+# This output writes events to MongoDB.
 class LogStash::Outputs::Mongodb < LogStash::Outputs::Base
 
   config_name "mongodb"
 
-  # a MongoDB URI to connect to
-  # See http://docs.mongodb.org/manual/reference/connection-string/
+  # A MongoDB URI to connect to.
+  # See http://docs.mongodb.org/manual/reference/connection-string/.
   config :uri, :validate => :string, :required => true
 
-  # The database to use
+  # The database to use.
   config :database, :validate => :string, :required => true
 
   # The collection to use. This value can use `%{foo}` values to dynamically
   # select a collection based on data in the event.
   config :collection, :validate => :string, :required => true
 
-  # If true, store the @timestamp field in mongodb as an ISODate type instead
+  # If true, store the @timestamp field in MongoDB as an ISODate type instead
   # of an ISO8601 string.  For more information about this, see
-  # http://www.mongodb.org/display/DOCS/Dates
+  # http://www.mongodb.org/display/DOCS/Dates.
   config :isodate, :validate => :boolean, :default => false
 
-  # Number of seconds to wait after failure before retrying
+  # The number of seconds to wait after failure before retrying.
   config :retry_delay, :validate => :number, :default => 3, :required => false
 
   # If true, an "_id" field will be added to the document before insertion.

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Store events into MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Removes extra comment in order to fix the docgen issue described in elastic/logstash#6692. Also adds a short description (plus a few minor edits) to fix quality issues tracked in https://github.com/elastic/logstash/issues/6693.
