### PR TITLE
Update mongo deps to 2.4.3

### DIFF
--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mongo', '~> 2.0.6'
+  s.add_runtime_dependency 'mongo', '~> 2.4.3'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
According to https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#ruby-driver-compatibility, this is not a breaking change. The old driver supports only until 3.0

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
