### PR TITLE
handle no @timestamp and fix generateId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+  - Fixed @timestamp handling, BSON::ObjectId generation, close method [#57](https://github.com/logstash-plugins/logstash-output-mongodb/pull/57)
+
 ## 3.1.4
   - Docs: Set the default_codec doc attribute.
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * bitsofinfo (bitsofinfo)
 * Guy Boertje (guyboertje)
+* Colin Surprenant (colinsurprenant)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.1.4'
+  s.version         = '3.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
fixes #25 #49

- do not add a `@timestamp` in the MongoDB document if the event does not contain a `@timestamp`
- fix the `generateId` `BSON::ObjectId` generation
- correctly handle close by exiting bulk thread
- added corresponding specs
