### PR TITLE
fix BigDecimal and Timestamp encoding and update driver to v2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.6
+  - Fixes BigDecimal and Timestamp encoding and update driver to v2.6 [#59](https://github.com/logstash-plugins/logstash-output-mongodb/pull/59)
+
 ## 3.1.5
   - Fixed @timestamp handling, BSON::ObjectId generation, close method [#57](https://github.com/logstash-plugins/logstash-output-mongodb/pull/57)
 

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -44,7 +44,7 @@ module BSON
       # @return [ BigDecimal ] The decoded BigDecimal.
       # @see http://bsonspec.org/#/specification
       def from_bson(bson)
-        from_bson_double(bson.read(8))
+        from_bson_double(bson.get_bytes(8))
       end
 
       private

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -33,8 +33,8 @@ module BSON
     #   1.221311.to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-    def to_bson(encoded = ''.force_encoding(BINARY))
-      encoded << [ self ].pack(PACK)
+    def to_bson(buffer = ByteBuffer.new)
+      buffer.put_bytes([ self ].pack(PACK))	
     end
 
     module ClassMethods

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -25,8 +25,8 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
 
-    def to_bson(encoded = ''.force_encoding(BINARY))
-      time.to_bson(encoded)
+    def to_bson(buffer = ByteBuffer.new)
+      time.to_bson(buffer)
     end
 
     module ClassMethods

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.1.5'
+  s.version         = '3.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'mongo', '~> 2.0.6'
+  s.add_runtime_dependency 'mongo', '~> 2.6'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/bson/big_decimal_spec.rb
+++ b/spec/bson/big_decimal_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require 'bigdecimal'
 require_relative "../spec_helper"
-require 'stringio'
 
 describe ::BigDecimal do
   let(:a_number) { "4321.1234" }
@@ -13,8 +12,8 @@ describe ::BigDecimal do
     expect(subject).to respond_to(:to_bson)
   end
 
-  it "to_bson returns a binary encoded number" do
-    expect(subject.to_bson).to eq(4321.1234.to_bson)
+  it "to_bson returns a binary encoded number  which can be encoded back from bson" do
+    expect(BigDecimal::from_bson(subject.to_bson)).to eq(BigDecimal::from_bson(4321.1234.to_bson))
   end
 
   it "bson_type returns a binary encoded 1" do
@@ -23,7 +22,7 @@ describe ::BigDecimal do
 
   describe "class methods" do
     it "builds a new BigDecimal from BSON" do
-      decoded = described_class.from_bson(StringIO.new(4321.1234.to_bson))
+      decoded = described_class.from_bson(4321.1234.to_bson)
       expect(decoded).to eql(BigDecimal.new(a_number))
     end
   end

--- a/spec/bson/logstash_timestamp_spec.rb
+++ b/spec/bson/logstash_timestamp_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require_relative "../spec_helper"
-require 'stringio'
 
 describe ::LogStash::Timestamp do
   let(:time_array) { [1918,11,11,11,0,0, "+00:00"] }
@@ -13,8 +12,8 @@ describe ::LogStash::Timestamp do
     expect(subject).to respond_to(:to_bson)
   end
 
-  it "to_bson returns a binary encoded timestamp" do
-    expect(timestamp.to_bson).to eq(bson_time)
+  it "to_bson returns a binary encoded timestamp which may be encoded back from bson" do
+    expect(Time::from_bson(timestamp.to_bson)).to eq(Time::from_bson(bson_time))
   end
 
   it "bson_type returns a binary encoded 9" do
@@ -24,7 +23,7 @@ describe ::LogStash::Timestamp do
   describe "class methods" do
     it "builds a new Timestamp from BSON" do
       expected = ::LogStash::Timestamp.new(a_time)
-      decoded = ::LogStash::Timestamp.from_bson(StringIO.new(bson_time))
+      decoded = ::LogStash::Timestamp.from_bson(bson_time)
       expect(decoded <=> expected).to eq(0)
     end
   end


### PR DESCRIPTION
This is a reboot of #52 with original commits by @sdmeisner and added version bump.