### PR TITLE
Fix "wrong number of arguments" error when shipping events to MongoDB (fixes #60, #64, #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.7
+  - Fix "wrong number of arguments" error when shipping events to MongoDB (fixes #60, #64, #65) [#66](https://api.github.com/repos/logstash-plugins/logstash-output-mongodb/pulls/66)
+
 ## 3.1.6
   - Fixes BigDecimal and Timestamp encoding and update driver to v2.6 [#59](https://github.com/logstash-plugins/logstash-output-mongodb/pull/59)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.7
-  - Fix "wrong number of arguments" error when shipping events to MongoDB (fixes #60, #64, #65) [#66](https://api.github.com/repos/logstash-plugins/logstash-output-mongodb/pulls/66)
+  - Fix "wrong number of arguments" error when shipping events to MongoDB (fixes #60, #64, #65) [#66](https://github.com/logstash-plugins/logstash-output-mongodb/pull/66)
 
 ## 3.1.6
   - Fixes BigDecimal and Timestamp encoding and update driver to v2.6 [#59](https://github.com/logstash-plugins/logstash-output-mongodb/pull/59)

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -33,7 +33,7 @@ module BSON
     #   1.221311.to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_bytes([ self ].pack(PACK))	
     end
 

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -30,7 +30,7 @@ module BSON
     #   Event.new("field" => "value").to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-     def to_bson(buffer = ByteBuffer.new)
+     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       position = buffer.length
       buffer.put_int32(0)
       to_hash.each do |field, value|

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -25,7 +25,7 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
 
-    def to_bson(buffer = ByteBuffer.new)
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       time.to_bson(buffer)
     end
 

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.1.6'
+  s.version         = '3.1.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Commit c7c07a8 introduced an update to the underlying Ruby Mongo driver, which changed the method signature of the `to_bson` method and causing this error to be seen due to the two signatures no longer aligning. This commit adds the missing (new) method parameter and resolves this issue.