### PR TITLE
Remove timezone field from time_array in spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## #unreleased
+  - Fix: Fix failing test spec on jruby-9.3.4.0 [#81](https://github.com/logstash-plugins/logstash-output-mongodb/pull/81)
+
 ## 3.1.7
   - Fix "wrong number of arguments" error when shipping events to MongoDB (fixes #60, #64, #65) [#66](https://github.com/logstash-plugins/logstash-output-mongodb/pull/66)
 

--- a/spec/bson/logstash_timestamp_spec.rb
+++ b/spec/bson/logstash_timestamp_spec.rb
@@ -2,7 +2,7 @@
 require_relative "../spec_helper"
 
 describe ::LogStash::Timestamp do
-  let(:time_array) { [1918,11,11,11,0,0, "+00:00"] }
+  let(:time_array) { [1918,11,11,11,0,0] }
   let(:a_time) { Time.utc(*time_array) }
   let(:bson_time) { Time.utc(*time_array).to_bson }
 


### PR DESCRIPTION
Specifying a timezone in Time#utc in jruby-9.3.4.0 raises a
`no implicit conversion of String into Integer` error.
AFAICT, this timezone serves no purpose in the running of the test, so this
commit removes it

