### PR TITLE
fix #88 and many others with Failed to handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## #unreleased
+## 3.1.8
+  - Fix tests failture for  ELASTIC_STACK_VERSION=8.x.  Fail message:  undefined method `validating_keys?' for BSON::Config:Module 
+  - Fix MongoDB connection error - Failed to handshake [#88] https://github.com/logstash-plugins/logstash-output-mongodb/issues/88
   - Fix: Fix failing test spec on jruby-9.3.4.0 [#81](https://github.com/logstash-plugins/logstash-output-mongodb/pull/81)
 
 ## 3.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.8
   - Fix tests failture for  ELASTIC_STACK_VERSION=8.x.  Fail message:  undefined method `validating_keys?' for BSON::Config:Module 
-  - Fix MongoDB connection error - Failed to handshake [#88] https://github.com/logstash-plugins/logstash-output-mongodb/issues/88
+  - Fix MongoDB connection error - Failed to handshake [#88]https://github.com/logstash-plugins/logstash-output-mongodb/issues/88
   - Fix: Fix failing test spec on jruby-9.3.4.0 [#81](https://github.com/logstash-plugins/logstash-output-mongodb/pull/81)
 
 ## 3.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.8
-  - Fix tests failture for  ELASTIC_STACK_VERSION=8.x.  Fail message:  undefined method `validating_keys?' for BSON::Config:Module 
-  - Fix MongoDB connection error - Failed to handshake [#88]https://github.com/logstash-plugins/logstash-output-mongodb/issues/88
+  - Fix tests failture for  ELASTIC_STACK_VERSION=8.x. Fail message: undefined method `validating_keys?' for BSON::Config:Module [#89](https://github.com/logstash-plugins/logstash-output-mongodb/pull/89)
+  - Fix MongoDB connection error - Failed to handshake [#88](https://github.com/logstash-plugins/logstash-output-mongodb/issues/88
   - Fix: Fix failing test spec on jruby-9.3.4.0 [#81](https://github.com/logstash-plugins/logstash-output-mongodb/pull/81)
 
 ## 3.1.7

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Contributors:
 * bitsofinfo (bitsofinfo)
 * Guy Boertje (guyboertje)
 * Colin Surprenant (colinsurprenant)
+* Vitalii Zavadovskyy
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -33,8 +33,8 @@ module BSON
     #   1.221311.to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
-      buffer.put_bytes([ self ].pack(PACK))	
+    def to_bson(buffer = ByteBuffer.new, _validating_keys = nil)
+      buffer.put_bytes([ self ].pack(PACK))
     end
 
     module ClassMethods

--- a/lib/logstash/outputs/bson/big_decimal.rb
+++ b/lib/logstash/outputs/bson/big_decimal.rb
@@ -43,7 +43,7 @@ module BSON
       # @param [ BSON ] bson object from Mongo.
       # @return [ BigDecimal ] The decoded BigDecimal.
       # @see http://bsonspec.org/#/specification
-      def from_bson(bson)
+      def from_bson(bson, **_options)
         from_bson_double(bson.get_bytes(8))
       end
 

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -55,7 +55,7 @@ module BSON
       # @param [ ByteBuffer ] buffer The byte buffer.
       # @return [ Event ] The decoded bson document.
       # @see http://bsonspec.org/#/specification
-      def from_bson(buffer)
+      def from_bson(buffer, **_options)
         hash = Hash.new
         buffer.get_int32 # Throw away the size.
         while (type = buffer.get_byte) != NULL_BYTE

--- a/lib/logstash/outputs/bson/logstash_event.rb
+++ b/lib/logstash/outputs/bson/logstash_event.rb
@@ -30,7 +30,7 @@ module BSON
     #   Event.new("field" => "value").to_bson
     # @return [ String ] The encoded string.
     # @see http://bsonspec.org/#/specification
-     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
+     def to_bson(buffer = ByteBuffer.new, _validating_keys = nil)
       position = buffer.length
       buffer.put_int32(0)
       to_hash.each do |field, value|

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -25,7 +25,7 @@ module BSON
     # A time is type 0x09 in the BSON spec.
     BSON_TYPE = 9.chr.force_encoding(BINARY).freeze
 
-    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
+    def to_bson(buffer = ByteBuffer.new, _validating_keys = nil)
       time.to_bson(buffer)
     end
 

--- a/lib/logstash/outputs/bson/logstash_timestamp.rb
+++ b/lib/logstash/outputs/bson/logstash_timestamp.rb
@@ -34,7 +34,7 @@ module BSON
       # @param [ BSON ] bson encoded time.
       # @return [ ::LogStash::Timestamp ] The decoded UTC time as a ::LogStash::Timestamp.
       # @see http://bsonspec.org/#/specification
-      def from_bson(bson)
+      def from_bson(bson, **_options)
         seconds, fragment = BSON::Int64.from_bson(bson).divmod(1000)
         new(::Time.at(seconds, fragment * 1000).utc)
       end

--- a/logstash-output-mongodb.gemspec
+++ b/logstash-output-mongodb.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-mongodb'
-  s.version         = '3.1.7'
+  s.version         = '3.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to MongoDB"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Hello! Please merge this pull request because this issue prevents the use of this plugin already for two years!!! There are many issues related to this problem but no one fixed it. The fix is elementary.

Error: MONGODB | Failed to handshake with test-mongo: 27017, wrong number of arguments (given 2, expected 1) 
 
Backtrace :
  "/usr/share/logstash/vendor/logstash-output-mongodb/lib/logstash/outputs/bson/logstash_timestamp.rb:37:in `from_bson'",
  "/usr/share/logstash/vendor/bundle/jruby/2.5.0/gems/bson-4.15.0-java/lib/bson/hash.rb:123:in `from_bson'"
  
File:   bson-4.15.0-java/lib/bson/hash.rb:123 ^

```
115          while (type = buffer.get_byte) != NULL_BYTE
116            field = buffer.get_cstring
117            cls = BSON::Registry.get(type, field)
118            value = if options.empty?
119             # Compatibility with the older Ruby driver versions which define
120              # a DBRef class with from_bson accepting a single argument.
121             cls.from_bson(buffer)
122            else
123              cls.from_bson(buffer, **options)  **<<-  the call here  with 2 arguments, but all definitions were done for single arg**
124            end
125            hash.store(field, value)
126          end
```

closes https://github.com/logstash-plugins/logstash-output-mongodb/issues/90